### PR TITLE
Update Dockerfile: Change Python version to 3.12 for compatibility.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.13-alpine3.18 as base-image
+FROM python:3.12-alpine as base-image
 FROM base-image as builder
 ARG KERIPY_BRANCH=main
 


### PR DESCRIPTION
This PR updates the Dockerfile to use python:3.12-alpine instead of python:3.10.13-alpine3.18, ensuring compatibility with the latest Python version while maintaining the current build process.