### PR TITLE
chore: migrate hardcoded runner labels to ${{ vars.RUNNER_TYPE }}

### DIFF
--- a/.github/workflows/check-schemas.yml
+++ b/.github/workflows/check-schemas.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check-schemas:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_TYPE }}
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Replaces hardcoded `ubuntu-latest` / `ubuntu-24.04` with the org-standard `${{ vars.RUNNER_TYPE }}` variable so runner selection is controlled centrally via GitHub repo/org variables.